### PR TITLE
refactor: rename color variables to match design naming

### DIFF
--- a/src/features/modals/canva/components/Sidebar/NavUser.tsx
+++ b/src/features/modals/canva/components/Sidebar/NavUser.tsx
@@ -33,7 +33,7 @@ export function NavUser({
 					<DropdownMenuTrigger asChild>
 						<SidebarMenuButton
 							size="lg"
-							className="!h-[2.375rem] !w-[2.375rem] md:p-0 mx-auto text-gray"
+							className="!h-[2.375rem] !w-[2.375rem] md:p-0 mx-auto text-lighter-gray"
 						>
 							<Avatar className="!h-[2.375rem] !w-[2.375rem] mx-auto rounded-full">
 								<AvatarImage src={user.avatar} alt={user.name} />

--- a/src/features/modals/canva/components/Sidebar/SidebarContent.tsx
+++ b/src/features/modals/canva/components/Sidebar/SidebarContent.tsx
@@ -18,9 +18,9 @@ export const SidebarContentPrinc = ({
 	return (
 		<Sidebar
 			collapsible="none"
-			className="hidden flex-1 md:flex bg-hover-gray rounded-2xl p-[36px] text-white	"
+			className="hidden flex-1 md:flex bg-cuartenary-gray rounded-2xl p-[36px] text-white	"
 		>
-			<SidebarHeader className="gap-3.5 border-b border-gray p-4">
+			<SidebarHeader className="gap-3.5 border-b border-lighter-gray p-4">
 				<div className="flex w-full items-center justify-center">
 					<div className="text-base font-medium text-foreground text-white text-h3">
 						{activeItem?.title}

--- a/src/features/modals/canva/components/Sidebar/SidebarIcons.tsx
+++ b/src/features/modals/canva/components/Sidebar/SidebarIcons.tsx
@@ -53,7 +53,7 @@ export const SidebarIcons = ({
 											}
 										}}
 										isActive={activeItem?.title === item.title}
-										className="!h-[2.375rem] !w-[2.375rem] flex items-center justify-center mx-auto text-gray hover:bg-hover-gray hover:text-gray [&>svg]:w-[1.25rem] [&>svg]:h-[1.25rem]"
+										className="!h-[2.375rem] !w-[2.375rem] flex items-center justify-center mx-auto text-lighter-gray hover:bg-cuartenary-gray hover:text-lighter-gray [&>svg]:w-[1.25rem] [&>svg]:h-[1.25rem]"
 									>
 										{item.icon && item.icon}
 										<span className="md:hidden">{item.title}</span>

--- a/src/features/modals/canva/components/TableNode.tsx
+++ b/src/features/modals/canva/components/TableNode.tsx
@@ -19,9 +19,9 @@ const AttributeNode = ({ column }: { column: Column }) => {
 		<div className="table-attribute">
 			<span className="text-white">{column.name}</span>
 			<div>
-				<span className="text-gray">{column.type}</span>
+				<span className="text-lighter-gray">{column.type}</span>
 				<div className="table-attribute__options">
-					<MoreButton className="text-gray" />
+					<MoreButton className="text-lighter-gray" />
 				</div>
 			</div>
 		</div>
@@ -36,7 +36,7 @@ export const TableNode = ({ data }: { data: TableData }) => {
 			{/* table header */}
 			<div className="table-header text-white">
 				<span>{data.label}</span>
-				<MoreButton className="hover:text-gray" />
+				<MoreButton className="hover:text-lighter-gray" />
 			</div>
 			{/* table content */}
 			<div className="table-content">
@@ -46,7 +46,7 @@ export const TableNode = ({ data }: { data: TableData }) => {
 						<React.Fragment key={column.id}>
 							<AttributeNode column={column} />
 							{index < data.columns.length - 1 && (
-								<hr className="border border-border-gray" />
+								<hr className="border border-gray" />
 							)}
 						</React.Fragment>
 					))}

--- a/src/index.css
+++ b/src/index.css
@@ -19,9 +19,9 @@
   --color-terciary-gray: #232323;
   --color-white: #DFDFDF;
   --color-secondary-white: #9d9d9d;
-  --color-gray: #747474;
-  --color-border-gray: #363636;
-  --color-hover-gray: #292929;
+  --color-lighter-gray: #747474;
+  --color-gray: #363636;
+  --color-cuartenary-gray: #292929;
   --color-red: #E93544;
   --color-green: #006239;
 
@@ -230,7 +230,7 @@
   --sidebar-foreground: oklch(0.147 0.004 49.25);
   --sidebar-primary: oklch(0.216 0.006 56.043);
   --sidebar-primary-foreground: oklch(0.985 0.001 106.423);
-  --sidebar-accent: var(--color-border-gray);
+  --sidebar-accent: var(--color-gray);
   --sidebar-accent-foreground: var(--color-white);
   --sidebar-border: oklch(0.923 0.003 48.717);
   --sidebar-ring: oklch(0.709 0.01 56.259);
@@ -280,7 +280,7 @@
 }
 
 .table {
-  @apply border border-border-gray rounded-xl;
+  @apply border border-gray rounded-xl;
 }
 
 .table-header {
@@ -296,7 +296,7 @@
 }
 
 .table-attributes div {
-  @apply text-gray flex gap-2.5 items-center;
+  @apply text-lighter-gray flex gap-2.5 items-center;
 }
 
 .nested-table .table-attribute:last-child {


### PR DESCRIPTION
### Changes
Renamed the following color variables for consistency with the design system:
- `gray` → `lighter gray`
- `bordar gray` → `gray`
- `hover gray` → `cuartenary gray`

---

#16 
