### PR TITLE
1 fix show a solution in diagram

### DIFF
--- a/src/features/modals/canva/DiagramView.tsx
+++ b/src/features/modals/canva/DiagramView.tsx
@@ -1,11 +1,82 @@
 import DatabaseDiagram from "./components/DataBaseDiagram";
 import { LayoutDiagram } from "./LayoutDiagram";
 
-import type { Edge } from "@xyflow/react";
+import type { Edge, Node } from "@xyflow/react";
 import type { Route } from "./+types/DiagramView";
 import { get } from "http";
+import type {
+  EdgeBackend,
+  NestedNode,
+  NodeBackend,
+  SolutionModel,
+  TableData,
+} from "./types";
 
 const backendUrl = import.meta.env.VITE_BACKEND_URL;
+
+/**
+ * Transforms a SolutionModel into an object with:
+ * - name: the solution's name
+ * - initialNodes: all nodes from all submodels, converted to TableData
+ * - initialEdges: all edges from all submodels
+ *
+ * Each NodeBackend is mapped to TableData.
+ */
+export function transformSolutionModel(solution: SolutionModel): {
+  name: string;
+  initialNodes: Node<TableData>[];
+  initialEdges: EdgeBackend[];
+} {
+  /**
+   * Maps a NodeBackend or NestedNode to a Node<TableData> object.
+   * Nested nodes are recursively mapped to nestedTables.
+   * For NestedNode, missing properties like position are set to default values.
+   */
+  function mapNode(node: NodeBackend | NestedNode): Node<TableData> {
+    const mappedNode: Node<TableData> = {
+      id: node.id,
+      // Use node.position if available, otherwise provide a default position for NestedNode
+      position: "position" in node ? node.position : { x: 0, y: 0 },
+      type: "table",
+      data: {
+        label: node.name,
+        columns: node.cols.map((col) => ({
+          id: col.id,
+          name: col.name,
+          type: col.type,
+        })),
+        // Map nested nodes to their TableData by extracting the .data property
+        nestedTables: mapNestedNode(node.nested_nodes || []),
+      },
+    };
+    return mappedNode;
+  }
+
+  function mapNestedNode(nestedNodes: NestedNode[]): TableData[] {
+    return nestedNodes.map((nestedNode) => ({
+      id: nestedNode.id,
+      label: nestedNode.name,
+      columns: nestedNode.cols.map((col) => ({
+        id: col.id,
+        name: col.name,
+        type: col.type,
+      })),
+      nestedTables: mapNestedNode(nestedNode.nested_nodes || []),
+    }));
+  }
+
+  const initialNodes = solution.submodels.flatMap((submodel) =>
+    submodel.nodes.map((node) => mapNode(node))
+  );
+
+  const initialEdges = solution.submodels.flatMap((submodel) => submodel.edges);
+
+  return {
+    name: solution.name,
+    initialNodes,
+    initialEdges,
+  };
+}
 
 export async function loader({ params }: Route.LoaderArgs) {
   const url = `${backendUrl}/solutions/${params.diagramId}`;
@@ -20,25 +91,23 @@ export async function loader({ params }: Route.LoaderArgs) {
   if (!response.ok) {
     throw new Error(data.detail);
   }
-  return data;
+  return transformSolutionModel(data);
 }
 
 // Placeholder for future action functionality. This function is intentionally left empty.
 export async function action() {}
 
 export default function DiagramView({ loaderData }: Route.ComponentProps) {
-  const initialEdges: Edge[] = [
-    { id: "edge1", source: "table1", target: "table2", type: "smoothstep" },
-  ];
+  console.log("DiagramView", loaderData);
 
-	return (
-		<>
-			<LayoutDiagram title={loaderData.name}>
-				<DatabaseDiagram
-					initialNodes={loaderData.submodels}
-					initialEdges={initialEdges}
-				/>
-			</LayoutDiagram>
-		</>
-	);
+  return (
+    <>
+      <LayoutDiagram title={loaderData.name}>
+        <DatabaseDiagram
+          initialNodes={loaderData.initialNodes}
+          initialEdges={loaderData.initialEdges}
+        />
+      </LayoutDiagram>
+    </>
+  );
 }

--- a/src/features/modals/canva/DiagramView.tsx
+++ b/src/features/modals/canva/DiagramView.tsx
@@ -1,82 +1,10 @@
 import DatabaseDiagram from "./components/DataBaseDiagram";
 import { LayoutDiagram } from "./LayoutDiagram";
 
-import type { Edge, Node } from "@xyflow/react";
 import type { Route } from "./+types/DiagramView";
-import { get } from "http";
-import type {
-  EdgeBackend,
-  NestedNode,
-  NodeBackend,
-  SolutionModel,
-  TableData,
-} from "./types";
+import { transformSolutionModel } from "@/lib/solutionConversion";
 
 const backendUrl = import.meta.env.VITE_BACKEND_URL;
-
-/**
- * Transforms a SolutionModel into an object with:
- * - name: the solution's name
- * - initialNodes: all nodes from all submodels, converted to TableData
- * - initialEdges: all edges from all submodels
- *
- * Each NodeBackend is mapped to TableData.
- */
-export function transformSolutionModel(solution: SolutionModel): {
-  name: string;
-  initialNodes: Node<TableData>[];
-  initialEdges: EdgeBackend[];
-} {
-  /**
-   * Maps a NodeBackend or NestedNode to a Node<TableData> object.
-   * Nested nodes are recursively mapped to nestedTables.
-   * For NestedNode, missing properties like position are set to default values.
-   */
-  function mapNode(node: NodeBackend | NestedNode): Node<TableData> {
-    const mappedNode: Node<TableData> = {
-      id: node.id,
-      // Use node.position if available, otherwise provide a default position for NestedNode
-      position: "position" in node ? node.position : { x: 0, y: 0 },
-      type: "table",
-      data: {
-        label: node.name,
-        columns: node.cols.map((col) => ({
-          id: col.id,
-          name: col.name,
-          type: col.type,
-        })),
-        // Map nested nodes to their TableData by extracting the .data property
-        nestedTables: mapNestedNode(node.nested_nodes || []),
-      },
-    };
-    return mappedNode;
-  }
-
-  function mapNestedNode(nestedNodes: NestedNode[]): TableData[] {
-    return nestedNodes.map((nestedNode) => ({
-      id: nestedNode.id,
-      label: nestedNode.name,
-      columns: nestedNode.cols.map((col) => ({
-        id: col.id,
-        name: col.name,
-        type: col.type,
-      })),
-      nestedTables: mapNestedNode(nestedNode.nested_nodes || []),
-    }));
-  }
-
-  const initialNodes = solution.submodels.flatMap((submodel) =>
-    submodel.nodes.map((node) => mapNode(node))
-  );
-
-  const initialEdges = solution.submodels.flatMap((submodel) => submodel.edges);
-
-  return {
-    name: solution.name,
-    initialNodes,
-    initialEdges,
-  };
-}
 
 export async function loader({ params }: Route.LoaderArgs) {
   const url = `${backendUrl}/solutions/${params.diagramId}`;
@@ -98,8 +26,6 @@ export async function loader({ params }: Route.LoaderArgs) {
 export async function action() {}
 
 export default function DiagramView({ loaderData }: Route.ComponentProps) {
-  console.log("DiagramView", loaderData);
-
   return (
     <>
       <LayoutDiagram title={loaderData.name}>

--- a/src/features/modals/canva/components/DataBaseDiagram.tsx
+++ b/src/features/modals/canva/components/DataBaseDiagram.tsx
@@ -8,12 +8,12 @@ import {
   useEdgesState,
 } from "@xyflow/react";
 import type { Node, Edge } from "@xyflow/react";
-import type { TableData } from "./TableNode";
 
 import { nodeTypes } from "./TableNode";
 import AddDocumentModal from "./AddDocumentModal";
 import "@xyflow/react/dist/style.css";
 import { Button } from "@/components/ui/button";
+import type { TableData } from "../types";
 
 const DatabaseDiagram = ({
   initialNodes,
@@ -40,31 +40,28 @@ const DatabaseDiagram = ({
     setNodes((prev) => [...prev, newNode]);
   };
 
-	return (
-		<div className="w-full h-full relative pb-[16px] pl-[5px] pr-[16px] pt-[2px]">
-			<Button
-				type="button"
-				onClick={() => setIsModalOpen(true)}
-				className="absolute top-5 right-10 bg-green text-white hover:bg-green-dark z-10 cursor-pointer"
-			>
-				<span className="text-xl">+</span> Nueva Colección
-			</Button>
+  return (
+    <div className="w-full h-full relative pb-[16px] pl-[5px] pr-[16px] pt-[2px]">
+      <Button
+        type="button"
+        onClick={() => setIsModalOpen(true)}
+        className="absolute top-5 right-10 bg-green text-white hover:bg-green-dark z-10 cursor-pointer"
+      >
+        <span className="text-xl">+</span> Nueva Colección
+      </Button>
 
-			<ReactFlow
-				nodes={nodes}
-				edges={edges}
-				onNodesChange={onNodesChange}
-				onEdgesChange={onEdgesChange}
-				nodeTypes={nodeTypes}
-				fitView
-			>
-				<Background className="!bg-terciary-gray rounded-xl" />
-				<Controls className="text-white controls-with-buttons " />
-				<MiniMap
-					nodeClassName="!fill-gray"
-					className="!bg-secondary-gray"
-				/>
-			</ReactFlow>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        nodeTypes={nodeTypes}
+        fitView
+      >
+        <Background className="!bg-terciary-gray rounded-xl" />
+        <Controls className="text-white controls-with-buttons " />
+        <MiniMap nodeClassName="!fill-gray" className="!bg-secondary-gray" />
+      </ReactFlow>
 
       {isModalOpen && (
         <AddDocumentModal

--- a/src/features/modals/canva/components/TableNode.tsx
+++ b/src/features/modals/canva/components/TableNode.tsx
@@ -10,24 +10,7 @@ import {
 import { ManagedDropdownMenu } from "@/components/managed-dropdown-menu";
 import type { Node } from "@xyflow/react";
 import { useReactFlow } from "@xyflow/react";
-
-interface Column {
-  id: string;
-  name: string;
-  type: string;
-}
-
-export interface TableData {
-  [key: string]: unknown;
-  label: string;
-  columns: Column[];
-  nestedTables?: TableData[];
-}
-
-interface AttributeNodeProps {
-  column: Column;
-  nodeId: string;
-}
+import type { AttributeNodeProps, TableData, TableNodeProps } from "../types";
 
 const AttributeNode = ({ column, nodeId }: AttributeNodeProps) => {
   const { setNodes } = useReactFlow();
@@ -37,42 +20,46 @@ const AttributeNode = ({ column, nodeId }: AttributeNodeProps) => {
       return nodes.map((node: Node) => {
         if (node.id === nodeId) {
           const tableData = node.data as TableData;
-          
-          const updateNestedTables = (tables: TableData[] | undefined): TableData[] | undefined => {
+
+          const updateNestedTables = (
+            tables: TableData[] | undefined
+          ): TableData[] | undefined => {
             if (!tables || tables.length === 0) return tables;
-            
-            return tables.map(table => {
-              if (table.columns.some(col => col.id === column.id)) {
+
+            return tables.map((table) => {
+              if (table.columns.some((col) => col.id === column.id)) {
                 return {
                   ...table,
-                  columns: table.columns.filter(col => col.id !== column.id)
+                  columns: table.columns.filter((col) => col.id !== column.id),
                 };
               }
               return {
                 ...table,
-                nestedTables: updateNestedTables(table.nestedTables)
+                nestedTables: updateNestedTables(table.nestedTables),
               };
             });
           };
-          
-          const updatedColumns = tableData.columns.filter(col => col.id !== column.id);
-          
+
+          const updatedColumns = tableData.columns.filter(
+            (col) => col.id !== column.id
+          );
+
           if (updatedColumns.length === tableData.columns.length) {
             return {
               ...node,
               data: {
                 ...tableData,
-                nestedTables: updateNestedTables(tableData.nestedTables)
-              }
+                nestedTables: updateNestedTables(tableData.nestedTables),
+              },
             };
           }
-          
+
           return {
             ...node,
             data: {
               ...tableData,
-              columns: updatedColumns
-            }
+              columns: updatedColumns,
+            },
           };
         }
         return node;
@@ -101,11 +88,7 @@ const AttributeNode = ({ column, nodeId }: AttributeNodeProps) => {
               side="right"
               variant="menu-1"
             >
-              <DropdownMenuItem
-                type="normal"
-                onClick={() => {
-                }}
-              >
+              <DropdownMenuItem type="normal" onClick={() => {}}>
                 <svg
                   width="16"
                   height="16"
@@ -121,7 +104,11 @@ const AttributeNode = ({ column, nodeId }: AttributeNodeProps) => {
                 Editar
               </DropdownMenuItem>
               <DropdownMenuSeparator className="bg-gray" />
-              <DropdownMenuItem type="delete" className="text-red" onClick={handleDeleteAttribute}>
+              <DropdownMenuItem
+                type="delete"
+                className="text-red"
+                onClick={handleDeleteAttribute}
+              >
                 <svg
                   width="15"
                   height="15"
@@ -144,44 +131,47 @@ const AttributeNode = ({ column, nodeId }: AttributeNodeProps) => {
   );
 };
 
-interface TableNodeProps {
-  data: TableData;
-  id: string;
-}
-
 export const TableNode = ({ data, id }: TableNodeProps) => {
   const { setNodes } = useReactFlow();
 
   const handleDeleteTable = () => {
     setNodes((nodes: Node[]) => {
-      return nodes.map((node: Node) => {
-        const findAndRemoveNestedTable = (tables: TableData[] | undefined): TableData[] | undefined => {
-          if (!tables || tables.length === 0) return tables;
-          
-          const filteredTables = tables.filter(table => table.label !== data.label);
-          
-          if (filteredTables.length < tables.length) {
-            return filteredTables;
+      return nodes
+        .map((node: Node) => {
+          const findAndRemoveNestedTable = (
+            tables: TableData[] | undefined
+          ): TableData[] | undefined => {
+            if (!tables || tables.length === 0) return tables;
+
+            const filteredTables = tables.filter(
+              (table) => table.label !== data.label
+            );
+
+            if (filteredTables.length < tables.length) {
+              return filteredTables;
+            }
+
+            return filteredTables.map((table) => ({
+              ...table,
+              nestedTables: findAndRemoveNestedTable(table.nestedTables),
+            }));
+          };
+
+          if (node.data.label === data.label) {
+            return null;
           }
-          
-          return filteredTables.map(table => ({
-            ...table,
-            nestedTables: findAndRemoveNestedTable(table.nestedTables)
-          }));
-        };
-        
-        if (node.data.label === data.label) {
-          return null;
-        }
-        
-        return {
-          ...node,
-          data: {
-            ...node.data,
-            nestedTables: findAndRemoveNestedTable(node.data.nestedTables as TableData[] | undefined)
-          }
-        };
-      }).filter(Boolean) as Node[];
+
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              nestedTables: findAndRemoveNestedTable(
+                node.data.nestedTables as TableData[] | undefined
+              ),
+            },
+          };
+        })
+        .filter(Boolean) as Node[];
     });
   };
 
@@ -243,7 +233,11 @@ export const TableNode = ({ data, id }: TableNodeProps) => {
               Agregar documentos
             </DropdownMenuItem>
             <DropdownMenuSeparator className="bg-gray" />
-            <DropdownMenuItem type="delete" className="text-red" onClick={handleDeleteTable}>
+            <DropdownMenuItem
+              type="delete"
+              className="text-red"
+              onClick={handleDeleteTable}
+            >
               <svg
                 width="15"
                 height="15"

--- a/src/features/modals/canva/types.ts
+++ b/src/features/modals/canva/types.ts
@@ -1,0 +1,64 @@
+export interface Column {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface TableData {
+  [key: string]: unknown;
+  label: string;
+  columns: Column[];
+  nestedTables?: TableData[];
+}
+
+export interface AttributeNodeProps {
+  column: Column;
+  nodeId: string;
+}
+
+export interface TableNodeProps {
+  data: TableData;
+  id: string;
+}
+
+export interface Query {
+  full_query: string;
+  collections: string[];
+}
+
+export interface NodeBackend {
+  id: string;
+  name: string;
+  type: string;
+  cols: Column[];
+  position: {
+    x: number;
+    y: number;
+  };
+  nested_nodes?: NestedNode[];
+}
+
+export interface NestedNode {
+  id: string;
+  name: string;
+  cols: Column[];
+  nested_nodes?: NestedNode[];
+}
+
+export interface EdgeBackend {
+  id: string;
+  source: string;
+  target: string;
+}
+
+export interface Submodel {
+  nodes: NodeBackend[];
+  edges: EdgeBackend[];
+}
+
+export interface SolutionModel {
+  _id: string;
+  name: string;
+  queries: Query[];
+  submodels: Submodel[];
+}

--- a/src/index.css
+++ b/src/index.css
@@ -22,11 +22,11 @@
   --color-lighter-gray: #747474;
   --color-gray: #363636;
   --color-cuartenary-gray: #292929;
-  --color-red: #E93544;
-  --color-red-dark: #8C111D;
+  --color-red: #e93544;
+  --color-red-dark: #8c111d;
   --color-green: #006239;
-  --color-green-dark: #003D24;
-  --color-blue-dark: #00317A;
+  --color-green-dark: #003d24;
+  --color-blue-dark: #00317a;
 
   /* --font-*: initial; */
   --font-OpenSans: "DM Sans", sans-serif;
@@ -341,6 +341,6 @@
   @apply rounded-t-xl h-full w-full;
 }
 
-.controls-with-buttons :where(button) {
+.controls-with-buttons button {
   @apply bg-primary-gray border-none hover:bg-secondary-gray hover:text-white;
 }

--- a/src/lib/solutionConversion.ts
+++ b/src/lib/solutionConversion.ts
@@ -1,0 +1,72 @@
+import type { Node } from "@xyflow/react";
+import type {
+  EdgeBackend,
+  NestedNode,
+  NodeBackend,
+  SolutionModel,
+  TableData,
+} from "@/features/modals/canva/types";
+
+/**
+ * Transforms a SolutionModel into an object with:
+ * - name: the solution's name
+ * - initialNodes: all nodes from all submodels, converted to TableData
+ * - initialEdges: all edges from all submodels
+ *
+ * Each NodeBackend is mapped to TableData.
+ */
+export function transformSolutionModel(solution: SolutionModel): {
+  name: string;
+  initialNodes: Node<TableData>[];
+  initialEdges: EdgeBackend[];
+} {
+  /**
+   * Maps a NodeBackend or NestedNode to a Node<TableData> object.
+   * Nested nodes are recursively mapped to nestedTables.
+   * For NestedNode, missing properties like position are set to default values.
+   */
+  function mapNode(node: NodeBackend | NestedNode): Node<TableData> {
+    const mappedNode: Node<TableData> = {
+      id: node.id,
+      // Use node.position if available, otherwise provide a default position for NestedNode
+      position: "position" in node ? node.position : { x: 0, y: 0 },
+      type: "table",
+      data: {
+        label: node.name,
+        columns: node.cols.map((col) => ({
+          id: col.id,
+          name: col.name,
+          type: col.type,
+        })),
+        // Map nested nodes to their TableData by extracting the .data property
+        nestedTables: mapNestedNode(node.nested_nodes || []),
+      },
+    };
+    return mappedNode;
+  }
+
+  function mapNestedNode(nestedNodes: NestedNode[]): TableData[] {
+    return nestedNodes.map((nestedNode) => ({
+      id: nestedNode.id,
+      label: nestedNode.name,
+      columns: nestedNode.cols.map((col) => ({
+        id: col.id,
+        name: col.name,
+        type: col.type,
+      })),
+      nestedTables: mapNestedNode(nestedNode.nested_nodes || []),
+    }));
+  }
+
+  const initialNodes = solution.submodels.flatMap((submodel) =>
+    submodel.nodes.map((node) => mapNode(node))
+  );
+
+  const initialEdges = solution.submodels.flatMap((submodel) => submodel.edges);
+
+  return {
+    name: solution.name,
+    initialNodes,
+    initialEdges,
+  };
+}


### PR DESCRIPTION
### Changes

#### Feature implemented

- New file: `src/features/modals/canva/types.ts`: A new typescript file is introduced, containing interfaces that define data structures used across the canva feature. This includes definitions for columns, tables, nodes, edges, submodels, and the solution model retrieved from the backend.
- Refactor: Removed interface/type for `TableData`, `Column`, `AttributeNodeProps`, and `TableNodeProps` from individual files (like `TableNode.tsx`) and imported them from the new `types.ts` file instead.
- New function: `trabsformSolutionModel` in `src/lib/solutionConversion.ts`
   - Purpose: converts a `SolutionModel` (as returned from the backend) into a format suitable for rendering in the frontend diagram.
   - How:
      - Extract all nodes and edges from all submodels.
      - Recursively maps nested nodes for hierarchical table structures.
      - Converts backend node/edges types into the format expected by the react flow library. 

#### Style correction

- The `.controls-with-buttons` CSS selector was simplified from using `:where(button)` to just `button`. Not functional changes, but the code is now more consistent and easier to read. 

---

#1 
