### PR TITLE
feat: add global state management with zustand

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"react-router-dom": "^7.3.0",
 		"tailwind-merge": "^3.1.0",
 		"tailwindcss": "^4.0.14",
-		"tw-animate-css": "^1.2.5"
+		"tw-animate-css": "^1.2.5",
+		"zustand": "^5.0.5"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       tw-animate-css:
         specifier: ^1.2.5
         version: 1.2.5
+      zustand:
+        specifier: ^5.0.5
+        version: 5.0.5(@types/react@19.0.10)(immer@10.1.1)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0))
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.4
@@ -2324,6 +2327,24 @@ packages:
       react:
         optional: true
 
+  zustand@5.0.5:
+    resolution: {integrity: sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -4261,3 +4282,10 @@ snapshots:
       '@types/react': 19.0.10
       immer: 10.1.1
       react: 19.0.0
+
+  zustand@5.0.5(@types/react@19.0.10)(immer@10.1.1)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0)):
+    optionalDependencies:
+      '@types/react': 19.0.10
+      immer: 10.1.1
+      react: 19.0.0
+      use-sync-external-store: 1.4.0(react@19.0.0)

--- a/src/features/modals/canva/DiagramView.tsx
+++ b/src/features/modals/canva/DiagramView.tsx
@@ -1,26 +1,33 @@
-import DatabaseDiagram from "./components/DataBaseDiagram";
-import { LayoutDiagram } from "./LayoutDiagram";
-
 import { isRouteErrorResponse } from "react-router";
 import type { Route } from "./+types/DiagramView";
+
 import { transformSolutionModel } from "@/lib/solutionConversion";
+import { useCanvasStore } from "@/state/canvaStore";
+
+import DatabaseDiagram from "./components/DataBaseDiagram";
+import { LayoutDiagram } from "./LayoutDiagram";
 
 const backendUrl = import.meta.env.VITE_BACKEND_URL;
 
 export async function loader({ params }: Route.LoaderArgs) {
-  const url = `${backendUrl}/solutions/${params.diagramId}`;
+  const { diagramId } = params;
+
+  const url = `${backendUrl}/solutions/${diagramId}`;
 
   if (import.meta.env.MODE !== "production") {
     console.log("URL", url);
   }
-  const response = await fetch(url, {
-    method: "GET",
-  });
+
+  const response = await fetch(url, { method: "GET" });
   const data = await response.json();
+
   if (!response.ok) {
     throw new Error(data.detail);
   }
-  return transformSolutionModel(data);
+
+
+  const transformed = transformSolutionModel(data);
+  return transformed;
 }
 
 // Placeholder for future action functionality. This function is intentionally left empty.
@@ -51,13 +58,18 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
 }
 
 export default function DiagramView({ loaderData }: Route.ComponentProps) {
+  const { setNodes, setEdges, setQueries, setId } = useCanvasStore.getState();
+  
+  setId(loaderData.solutionId);
+  setNodes(loaderData.initialNodes);
+  setEdges(loaderData.initialEdges);
+  setQueries(loaderData.queries);
+  
+
   return (
     <>
       <LayoutDiagram title={loaderData.name}>
-        <DatabaseDiagram
-          initialNodes={loaderData.initialNodes}
-          initialEdges={loaderData.initialEdges}
-        />
+        <DatabaseDiagram />
       </LayoutDiagram>
     </>
   );

--- a/src/features/modals/canva/DiagramView.tsx
+++ b/src/features/modals/canva/DiagramView.tsx
@@ -6,71 +6,80 @@ import { useCanvasStore } from "@/state/canvaStore";
 
 import DatabaseDiagram from "./components/DataBaseDiagram";
 import { LayoutDiagram } from "./LayoutDiagram";
+import { useEffect } from "react";
 
 const backendUrl = import.meta.env.VITE_BACKEND_URL;
 
 export async function loader({ params }: Route.LoaderArgs) {
-  const { diagramId } = params;
+	const { diagramId } = params;
 
-  const url = `${backendUrl}/solutions/${diagramId}`;
+	const url = `${backendUrl}/solutions/${diagramId}`;
 
-  if (import.meta.env.MODE !== "production") {
-    console.log("URL", url);
-  }
+	if (import.meta.env.MODE !== "production") {
+		console.log("URL", url);
+	}
 
-  const response = await fetch(url, { method: "GET" });
-  const data = await response.json();
+	const response = await fetch(url, { method: "GET" });
+	const data = await response.json();
 
-  if (!response.ok) {
-    throw new Error(data.detail);
-  }
+	if (!response.ok) {
+		throw new Error(data.detail);
+	}
 
-
-  const transformed = transformSolutionModel(data);
-  return transformed;
+	const transformed = transformSolutionModel(data);
+	return transformed;
 }
 
 // Placeholder for future action functionality. This function is intentionally left empty.
 export async function action() {}
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  if (isRouteErrorResponse(error)) {
-    return (
-      <>
-        <h1>
-          {error.status} {error.statusText}
-        </h1>
-        <p>{error.data}</p>
-      </>
-    );
-  }
-  if (error instanceof Error) {
-    return (
-      <div>
-        <h1>Error</h1>
-        <p>{error.message}</p>
-        <p>The stack trace is:</p>
-        <pre>{error.stack}</pre>
-      </div>
-    );
-  }
-  return <h1>Unknown Error</h1>;
+	if (isRouteErrorResponse(error)) {
+		return (
+			<>
+				<h1>
+					{error.status} {error.statusText}
+				</h1>
+				<p>{error.data}</p>
+			</>
+		);
+	}
+	if (error instanceof Error) {
+		return (
+			<div>
+				<h1>Error</h1>
+				<p>{error.message}</p>
+				<p>The stack trace is:</p>
+				<pre>{error.stack}</pre>
+			</div>
+		);
+	}
+	return <h1>Unknown Error</h1>;
 }
 
 export default function DiagramView({ loaderData }: Route.ComponentProps) {
-  const { setNodes, setEdges, setQueries, setId } = useCanvasStore.getState();
-  
-  setId(loaderData.solutionId);
-  setNodes(loaderData.initialNodes);
-  setEdges(loaderData.initialEdges);
-  setQueries(loaderData.queries);
-  
+	const { id, setNodes, setEdges, setQueries, setId, _hasHydrated } =
+		useCanvasStore.getState();
 
-  return (
-    <>
-      <LayoutDiagram title={loaderData.name}>
-        <DatabaseDiagram />
-      </LayoutDiagram>
-    </>
-  );
+	useEffect(() => {
+		if (_hasHydrated) {
+			if (id !== loaderData.solutionId) {
+				setId(loaderData.solutionId);
+				setNodes(loaderData.initialNodes);
+				setEdges(loaderData.initialEdges);
+				setQueries(loaderData.queries);
+			}
+		}
+	}, [_hasHydrated, loaderData, setEdges, setId, setNodes, setQueries, id]);
+
+	if (!_hasHydrated) {
+		return null;
+	}
+	return (
+		<>
+			<LayoutDiagram title={loaderData.name}>
+				<DatabaseDiagram />
+			</LayoutDiagram>
+		</>
+	);
 }

--- a/src/features/modals/canva/components/DataBaseDiagram.tsx
+++ b/src/features/modals/canva/components/DataBaseDiagram.tsx
@@ -17,7 +17,7 @@ import ShowErrorModal from "./ShowErrorModal";
 import { edgeTypes } from "./FloatingEdge";
 import { useTableConnections } from "@/hooks/use-node-connections";
 import { type CanvasState, useCanvasStore } from "@/state/canvaStore";
-import { shallow } from 'zustand/shallow';
+import { useShallow } from 'zustand/shallow';
 
 const connectionLineStyle = {
   stroke: "#4E4E4E",
@@ -44,7 +44,8 @@ const DatabaseDiagram = () => {
     addEdge,
     onNodesChange,
     onEdgesChange,
-  } = useCanvasStore<ReturnType<typeof selector>>(selector, shallow);
+  } = useCanvasStore<ReturnType<typeof selector>>(useShallow(selector));
+
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [showError, setShowError] = useState(false);

--- a/src/features/modals/canva/components/DataBaseDiagram.tsx
+++ b/src/features/modals/canva/components/DataBaseDiagram.tsx
@@ -4,11 +4,9 @@ import {
   Background,
   Controls,
   MiniMap,
-  useNodesState,
-  useEdgesState,
   MarkerType,
 } from "@xyflow/react";
-import type { Node, Edge } from "@xyflow/react";
+import type { Node } from "@xyflow/react";
 import type { TableData } from "../types";
 
 import { nodeTypes } from "./TableNode";
@@ -18,43 +16,54 @@ import { Button } from "@/components/ui/button";
 import ShowErrorModal from "./ShowErrorModal";
 import { edgeTypes } from "./FloatingEdge";
 import { useTableConnections } from "@/hooks/use-node-connections";
+import { type CanvasState, useCanvasStore } from "@/state/canvaStore";
+import { shallow } from 'zustand/shallow';
 
 const connectionLineStyle = {
   stroke: "#4E4E4E",
   strokeWidth: 3,
 };
 
-const DatabaseDiagram = ({
-  initialNodes,
-  initialEdges,
-}: {
-  initialNodes: Node<TableData>[];
-  initialEdges: Edge[];
-}) => {
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
-  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+const selector = (state: CanvasState) => ({
+  id: state.id,
+  nodes: state.nodes,
+  edges: state.edges,
+  setNodes: state.setNodes,
+  setEdges: state.setEdges,
+  onNodesChange: state.onNodesChange,
+  onEdgesChange: state.onEdgesChange,
+  addNode: state.addNode,
+});
+
+const DatabaseDiagram = () => {
+  const {
+    nodes,
+    edges,
+    addNode,
+    setNodes,
+    setEdges,
+    onNodesChange,
+    onEdgesChange,
+  } = useCanvasStore<ReturnType<typeof selector>>(selector, shallow);
+
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [showError, setShowError] = useState(false);
 
   const { handleConnect } = useTableConnections({
     nodes,
+    edges,
     setNodes,
     setEdges,
     onError: () => setShowError(true),
   });
 
-  const handleAddDocument = (name: string) => {
-    const newNode: Node<TableData> = {
-      id: `table-${nodes.length + 1}`,
-      position: { x: Math.random() * 400, y: Math.random() * 400 },
-      data: {
-        label: name,
+  const handleAddDocument = (name: string) => { const newNode: Node<TableData> = { id: `table-${nodes.length + 1}`, position: { x: Math.random() * 400, y: Math.random() * 400 }, data: { label: name,
         columns: [{ id: `col1${nodes.length + 1}`, name: "id", type: "INT" }],
       },
       type: "table",
     };
 
-    setNodes((prev) => [...prev, newNode]);
+    addNode(newNode);
   };
 
   return (

--- a/src/features/modals/canva/components/DataBaseDiagram.tsx
+++ b/src/features/modals/canva/components/DataBaseDiagram.tsx
@@ -28,8 +28,8 @@ const selector = (state: CanvasState) => ({
   id: state.id,
   nodes: state.nodes,
   edges: state.edges,
-  setNodes: state.setNodes,
-  setEdges: state.setEdges,
+  editNode: state.editNode,
+  addEdge: state.addEdge,
   onNodesChange: state.onNodesChange,
   onEdgesChange: state.onEdgesChange,
   addNode: state.addNode,
@@ -40,8 +40,8 @@ const DatabaseDiagram = () => {
     nodes,
     edges,
     addNode,
-    setNodes,
-    setEdges,
+    editNode,
+    addEdge,
     onNodesChange,
     onEdgesChange,
   } = useCanvasStore<ReturnType<typeof selector>>(selector, shallow);
@@ -51,13 +51,13 @@ const DatabaseDiagram = () => {
 
   const { handleConnect } = useTableConnections({
     nodes,
-    edges,
-    setNodes,
-    setEdges,
+    editNode,
+    addEdge,
     onError: () => setShowError(true),
   });
 
-  const handleAddDocument = (name: string) => { const newNode: Node<TableData> = { id: `table-${nodes.length + 1}`, position: { x: Math.random() * 400, y: Math.random() * 400 }, data: { label: name,
+  const handleAddDocument = (name: string) => { 
+    const newNode: Node<TableData> = { id: `table-${nodes.length + 1}`, position: { x: Math.random() * 400, y: Math.random() * 400 }, data: { label: name,
         columns: [{ id: `col1${nodes.length + 1}`, name: "id", type: "INT" }],
       },
       type: "table",

--- a/src/features/modals/canva/components/TableNode.tsx
+++ b/src/features/modals/canva/components/TableNode.tsx
@@ -1,55 +1,11 @@
 import { Handle, Position } from "@xyflow/react";
 import type { NodeTypes } from "@xyflow/react";
 
-import type { Node } from "@xyflow/react";
-import { useReactFlow } from "@xyflow/react";
-import type { TableData, TableNodeProps } from "../types";
+import type { TableNodeProps } from "../types";
 import { TableNodeContent } from "./TableNodeContent";
 
 // Custom node types
 export const TableNode = ({ data, id }: TableNodeProps) => {
-  const { setNodes } = useReactFlow();
-
-  const handleDeleteTable = () => {
-    setNodes((nodes: Node[]) => {
-      return nodes
-        .map((node: Node) => {
-          const findAndRemoveNestedTable = (
-            tables: TableData[] | undefined
-          ): TableData[] | undefined => {
-            if (!tables || tables.length === 0) return tables;
-
-            const filteredTables = tables.filter(
-              (table) => table.label !== data.label
-            );
-
-            if (filteredTables.length < tables.length) {
-              return filteredTables;
-            }
-
-            return filteredTables.map((table) => ({
-              ...table,
-              nestedTables: findAndRemoveNestedTable(table.nestedTables),
-            }));
-          };
-
-          if (node.data.label === data.label) {
-            return null;
-          }
-
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              nestedTables: findAndRemoveNestedTable(
-                node.data.nestedTables as TableData[] | undefined
-              ),
-            },
-          };
-        })
-        .filter(Boolean) as Node[];
-    });
-  };
 
   return (
     // table
@@ -72,7 +28,6 @@ export const TableNode = ({ data, id }: TableNodeProps) => {
       />
       <TableNodeContent
         data={data}
-        handleDeleteTable={handleDeleteTable}
         id={id}
       />
     </div>

--- a/src/features/modals/canva/types.ts
+++ b/src/features/modals/canva/types.ts
@@ -6,6 +6,7 @@ export interface Column {
 
 export interface TableData {
   [key: string]: unknown;
+  id: string;
   label: string;
   columns: Column[];
   nestedTables?: TableData[];
@@ -13,7 +14,7 @@ export interface TableData {
 
 export interface AttributeNodeProps {
   column: Column;
-  nodeId: string;
+  columnId: string;
 }
 
 export interface TableNodeProps {

--- a/src/hooks/use-node-connections.ts
+++ b/src/hooks/use-node-connections.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { addEdge, type Connection, type Node } from "@xyflow/react";
+import { addEdge, type Edge, type Connection, type Node } from "@xyflow/react";
 import type { TableData } from "@/features/modals/canva/types";
 
 export const existsConnection = (
@@ -17,13 +17,15 @@ export const existsConnection = (
 
 interface UseTableConnectionsProps {
   nodes: Node<TableData>[];
+  edges: Edge[];
   setNodes: (nodes: Node<TableData>[]) => void;
-  setEdges: (callback: (edges: any) => any) => void;
+  setEdges: (edges: Edge[]) => void;
   onError?: () => void;
 }
 
 export const useTableConnections = ({
   nodes,
+  edges,
   setNodes,
   setEdges,
   onError,
@@ -46,12 +48,12 @@ export const useTableConnections = ({
         const newNodes = [...nodes];
         newNodes[index] = targetNode;
         setNodes(newNodes);
-        setEdges((eds) => addEdge(params, eds));
+        setEdges(addEdge(params, edges));
       } else {
         onError?.();
       }
     },
-    [setEdges, nodes, setNodes, onError]
+    [setEdges, nodes, edges, setNodes, onError]
   );
 
   return { handleConnect };

--- a/src/lib/getKeySegment.ts
+++ b/src/lib/getKeySegment.ts
@@ -1,0 +1,7 @@
+const getKeySegment = (key: string, index: number): string | null => {
+  const parts = key.split("-");
+  if (index < 1 || index > parts.length) return null;
+  return parts.slice(0, index).join("-");
+};
+
+export default getKeySegment;

--- a/src/lib/solutionConversion.ts
+++ b/src/lib/solutionConversion.ts
@@ -3,6 +3,7 @@ import type {
   EdgeBackend,
   NestedNode,
   NodeBackend,
+  Query,
   SolutionModel,
   TableData,
 } from "@/features/modals/canva/types";
@@ -19,6 +20,8 @@ export function transformSolutionModel(solution: SolutionModel): {
   name: string;
   initialNodes: Node<TableData>[];
   initialEdges: EdgeBackend[];
+  queries: Query[];
+  solutionId: string;
 } {
   /**
    * Maps a NodeBackend or NestedNode to a Node<TableData> object.
@@ -63,10 +66,14 @@ export function transformSolutionModel(solution: SolutionModel): {
   );
 
   const initialEdges = solution.submodels.flatMap((submodel) => submodel.edges);
+  const queries = solution.queries
+
 
   return {
     name: solution.name,
     initialNodes,
     initialEdges,
+    queries,
+    solutionId: solution._id,
   };
 }

--- a/src/state/canvaStore.ts
+++ b/src/state/canvaStore.ts
@@ -1,0 +1,98 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { immer } from "zustand/middleware/immer";
+import type { Query, TableData } from "@/features/modals/canva/types";
+import { applyEdgeChanges, applyNodeChanges, type Edge, type EdgeChange, type Node, type NodeChange } from "@xyflow/react";
+
+export type CanvasState = {
+  nodes: Node<TableData>[];
+  edges: Edge[];
+  queries: Query[];
+  id: string;
+  setId: (id: string) => void;
+  setQueries: (queries: Query[]) => void;
+  setNodes: (nodes: Node<TableData>[]) => void;
+  setEdges: (edges: Edge[]) => void;
+  addNode: (node: Node<TableData>) => void;
+  addEdge: (edge: Edge) => void;
+  removeNode: (nodeId: string) => void;
+  removeEdge: (edgeId: string) => void;
+  removeQuery: (queryString: string) => void;
+  onNodesChange: (changes: NodeChange<Node<TableData>>[]) => void;
+  onEdgesChange: (changes: EdgeChange[]) => void;
+};
+
+
+export const useCanvasStore = create<CanvasState>()(
+  persist(
+    immer((set, get) => ({
+      nodes: [],
+      edges: [],
+      queries: [],
+      id: "",
+      setId: (id) => {
+        set((state) => {
+          state.id = id;
+        });
+      },
+      setQueries: (queries) => {
+        set((state) => {
+          state.queries = queries;
+        });
+      },
+      setNodes: (nodes) => {
+        set((state) => {
+          state.nodes = nodes;
+        });
+      },
+      setEdges: (edges) => {
+        set((state) => {
+          state.edges = edges;
+        });
+      },
+      addNode: (node) => {
+        set((state) => {
+          state.nodes.push(node);
+        });
+      },
+      addEdge: (edge) => {
+        set((state) => {
+          state.edges.push(edge);
+        });
+      },
+      removeNode: (nodeId) => {
+        set((state) => {
+          state.nodes = state.nodes.filter((n) => n.id !== nodeId);
+        });
+      },
+      removeEdge: (edgeId) => {
+        set((state) => {
+          state.edges = state.edges.filter((e) => e.id !== edgeId);
+        });
+      },
+      removeQuery: (queryString) => {
+        set((state) => {
+          state.queries = state.queries.filter((q) => q.full_query !== queryString);
+        });
+      },
+      onNodesChange: (changes: NodeChange<Node<TableData>>[]) => {
+        set({
+          nodes: applyNodeChanges<Node<TableData>>(changes, get().nodes),
+        });
+      },
+      onEdgesChange: (changes: EdgeChange[]) => {
+        set({
+          edges: applyEdgeChanges(changes, get().edges),
+        });
+      },
+    })),
+    {
+      name: "canvas-storage",
+      partialize: (state) => ({
+        nodes: state.nodes,
+        edges: state.edges,
+        queries: state.queries,
+      }),
+    }
+  )
+);

--- a/src/state/canvaStore.ts
+++ b/src/state/canvaStore.ts
@@ -15,6 +15,7 @@ export type CanvasState = {
   setEdges: (edges: Edge[]) => void;
   addNode: (node: Node<TableData>) => void;
   addEdge: (edge: Edge) => void;
+  editNode: (nodeId: string, newNode: Node<TableData>) => void;
   removeNode: (nodeId: string) => void;
   removeEdge: (edgeId: string) => void;
   removeQuery: (queryString: string) => void;
@@ -60,6 +61,14 @@ export const useCanvasStore = create<CanvasState>()(
           state.edges.push(edge);
         });
       },
+      editNode: (nodeId, newNode) => {
+        set((state) => {
+          const index = state.nodes.findIndex((node) => node.id === nodeId);
+          if (index !== -1) {
+            state.nodes[index] = newNode;
+          }
+        });
+      },
       removeNode: (nodeId) => {
         set((state) => {
           state.nodes = state.nodes.filter((n) => n.id !== nodeId);
@@ -76,8 +85,8 @@ export const useCanvasStore = create<CanvasState>()(
         });
       },
       onNodesChange: (changes: NodeChange<Node<TableData>>[]) => {
-        set({
-          nodes: applyNodeChanges<Node<TableData>>(changes, get().nodes),
+        set((state) => {
+          state.nodes = applyNodeChanges<Node<TableData>>(changes, state.nodes);
         });
       },
       onEdgesChange: (changes: EdgeChange[]) => {
@@ -89,6 +98,7 @@ export const useCanvasStore = create<CanvasState>()(
     {
       name: "canvas-storage",
       partialize: (state) => ({
+        id: state.id,
         nodes: state.nodes,
         edges: state.edges,
         queries: state.queries,

--- a/src/state/canvaStore.ts
+++ b/src/state/canvaStore.ts
@@ -21,6 +21,8 @@ export type CanvasState = {
   removeQuery: (queryString: string) => void;
   onNodesChange: (changes: NodeChange<Node<TableData>>[]) => void;
   onEdgesChange: (changes: EdgeChange[]) => void;
+  _hasHydrated: boolean;
+  setHasHydrated: (hasHydrated: boolean) => void;
 };
 
 
@@ -94,6 +96,8 @@ export const useCanvasStore = create<CanvasState>()(
           edges: applyEdgeChanges(changes, get().edges),
         });
       },
+      _hasHydrated: false,
+      setHasHydrated: (hasHydrated) => set({ _hasHydrated: hasHydrated }),
     })),
     {
       name: "canvas-storage",
@@ -103,6 +107,9 @@ export const useCanvasStore = create<CanvasState>()(
         edges: state.edges,
         queries: state.queries,
       }),
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+      },
     }
   )
 );


### PR DESCRIPTION
### Changes

- Added global state variables and functions: nodes, edges, queries, id, setNodes, setEdges, setQueries, setId, addNode, addEdge, editNode, removeNode, removeEdge, removeQuery, onNodesChange, onEdgesChange
- Enabled global access and usage of canvas state across components
- Fixed Zustand persist issue to maintain state after page reloads with hydration handling


---
#47 
