### PR TITLE
Change versions

### DIFF
--- a/src/features/modals/canva/DiagramView.tsx
+++ b/src/features/modals/canva/DiagramView.tsx
@@ -58,19 +58,44 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
 }
 
 export default function DiagramView({ loaderData }: Route.ComponentProps) {
-	const { id, setNodes, setEdges, setQueries, setId, _hasHydrated } =
-		useCanvasStore.getState();
+	const {
+		id,
+		setNodes,
+		setEdges,
+		setQueries,
+		setId,
+		setVersions,
+		setSelectedVersionId,
+		_hasHydrated,
+	} = useCanvasStore.getState();
+
+	const versionId = loaderData.versions.findIndex(
+		(version) => loaderData.last_version_saved === version._id
+	);
 
 	useEffect(() => {
 		if (_hasHydrated) {
 			if (id !== loaderData.solutionId) {
 				setId(loaderData.solutionId);
-				setNodes(loaderData.initialNodes);
-				setEdges(loaderData.initialEdges);
-				setQueries(loaderData.queries);
+				setNodes(loaderData.versions[versionId].nodes);
+				setEdges(loaderData.versions[versionId].edges);
+				setQueries(loaderData.versions[versionId].queries);
+				setVersions(loaderData.versions);
+				setSelectedVersionId(loaderData.versions[versionId]._id);
 			}
 		}
-	}, [_hasHydrated, loaderData, setEdges, setId, setNodes, setQueries, id]);
+	}, [
+		_hasHydrated,
+		loaderData,
+		versionId,
+		setEdges,
+		setId,
+		setNodes,
+		setQueries,
+		setVersions,
+		setSelectedVersionId,
+		id,
+	]);
 
 	if (!_hasHydrated) {
 		return null;

--- a/src/features/modals/canva/components/DataBaseDiagram.tsx
+++ b/src/features/modals/canva/components/DataBaseDiagram.tsx
@@ -16,7 +16,7 @@ import { Button } from "@/components/ui/button";
 import ShowErrorModal from "./ShowErrorModal";
 import { edgeTypes } from "./FloatingEdge";
 import { useTableConnections } from "@/hooks/use-node-connections";
-import { type CanvasState, useCanvasStore } from "@/state/canvaStore";
+import { canvaSelector, useCanvasStore } from "@/state/canvaStore";
 import { useShallow } from "zustand/shallow";
 import { useUniqueId } from "@/hooks/use-unique-id";
 
@@ -24,17 +24,6 @@ const connectionLineStyle = {
 	stroke: "#4E4E4E",
 	strokeWidth: 3,
 };
-
-const selector = (state: CanvasState) => ({
-	id: state.id,
-	nodes: state.nodes,
-	edges: state.edges,
-	editNode: state.editNode,
-	addEdge: state.addEdge,
-	onNodesChange: state.onNodesChange,
-	onEdgesChange: state.onEdgesChange,
-	addNode: state.addNode,
-});
 
 const DatabaseDiagram = () => {
 	const {
@@ -45,7 +34,9 @@ const DatabaseDiagram = () => {
 		addEdge,
 		onNodesChange,
 		onEdgesChange,
-	} = useCanvasStore<ReturnType<typeof selector>>(useShallow(selector));
+	} = useCanvasStore<ReturnType<typeof canvaSelector>>(
+		useShallow(canvaSelector)
+	);
 
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [showError, setShowError] = useState(false);

--- a/src/features/modals/canva/components/header/AppHeader.tsx
+++ b/src/features/modals/canva/components/header/AppHeader.tsx
@@ -6,17 +6,11 @@ import {
 } from "@/components/icons/HeaderIcons";
 
 import { LogoWithSelect } from "./LogoWithSelect";
-import type { VersionOption } from "./types";
-
-const Versions: VersionOption[] = [
-	{ value: "version1", label: "Versión 1" },
-	{ value: "version2", label: "Versión 2" },
-];
 
 export const AppHeader = ({ title }: { title: string }) => {
 	return (
 		<header className="flex flex-row items-center justify-between w-full h-16 bg-secondary-gray p-4 text-white">
-			<LogoWithSelect Versions={Versions} />
+			<LogoWithSelect />
 			<div className="flex items-center gap-8 mr-30">
 				<div className="flex items-center gap-4">
 					<ArrowLeft className="text-white" />

--- a/src/features/modals/canva/components/header/LogoWithSelect.tsx
+++ b/src/features/modals/canva/components/header/LogoWithSelect.tsx
@@ -6,29 +6,47 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
-import type { VersionOption } from "./types";
-import { useState } from "react";
+import { canvaSelector, useCanvasStore } from "@/state/canvaStore";
+import { useShallow } from "zustand/shallow";
 
 // components/header/LogoWithSelect.tsx
-export const LogoWithSelect = ({ Versions }: { Versions: VersionOption[] }) => {
-	const [selectedVersion, setSelectedVersion] = useState(
-		Versions[Versions.length - 1].value, // selecciona el último por defecto
+export const LogoWithSelect = () => {
+	const {
+		versions: Versions,
+		selectedVersionId,
+		setSelectedVersionId,
+		setNodes,
+		setEdges,
+		setQueries,
+	} = useCanvasStore<ReturnType<typeof canvaSelector>>(
+		useShallow(canvaSelector)
 	);
+
+	const onVersionChange = (newVersionId: string) => {
+		const versionIndex = Versions.findIndex(
+			(version) => version._id === newVersionId
+		);
+		setNodes(Versions[versionIndex].nodes);
+		setEdges(Versions[versionIndex].edges);
+		setQueries(Versions[versionIndex].queries);
+		setSelectedVersionId(newVersionId);
+	};
+
 	return (
 		<div className="flex items-center gap-8">
 			<Logo className="text-blue" />
-			<Select value={selectedVersion} onValueChange={setSelectedVersion}>
+			<Select value={selectedVersionId} onValueChange={onVersionChange}>
 				<SelectTrigger className="border-gray rounded-full !text-white text-h6 w-[153px] py-[7px] px-[20px]">
 					<SelectValue />
 				</SelectTrigger>
 				<SelectContent className="!text-white bg-secondary-gray border-gray p-[10px] w-[240px]">
 					{Versions.map((version) => (
 						<SelectItem
-							key={version.value}
-							value={version.value}
-							className="border-b-[1px] text-h6 rounded-none !border-cuartenary-gray hover:!bg-gray hover:!text-white focus:!bg-gray focus:!text-white rounded-md"
+							key={version._id}
+							value={version._id}
+							className="border-b-[1px] text-h6 !border-cuartenary-gray hover:!bg-gray hover:!text-white focus:!bg-gray focus:!text-white rounded-md"
 						>
-							{version.label}
+							{version.description}
 						</SelectItem>
 					))}
 				</SelectContent>

--- a/src/features/modals/canva/types.ts
+++ b/src/features/modals/canva/types.ts
@@ -1,3 +1,5 @@
+import type { Edge, Node } from "@xyflow/react";
+
 export interface Column {
 	id: string;
 	name: string;
@@ -57,9 +59,25 @@ export interface Submodel {
 	edges: EdgeBackend[];
 }
 
+export interface VersionBackend {
+	queries: Query[];
+	submodels: Submodel[];
+	description: string;
+	solution_id: string;
+	_id: string;
+}
+
 export interface SolutionModel {
 	_id: string;
 	name: string;
+	versions: VersionBackend[];
+}
+
+export interface VersionFrontend {
 	queries: Query[];
-	submodels: Submodel[];
+	nodes: Node<TableData>[];
+	edges: Edge[];
+	description: string;
+	solution_id: string;
+	_id: string;
 }

--- a/src/features/modals/canva/types.ts
+++ b/src/features/modals/canva/types.ts
@@ -71,6 +71,7 @@ export interface SolutionModel {
 	_id: string;
 	name: string;
 	versions: VersionBackend[];
+	last_version_saved: string;
 }
 
 export interface VersionFrontend {

--- a/src/lib/solutionConversion.ts
+++ b/src/lib/solutionConversion.ts
@@ -1,11 +1,10 @@
 import type { Node } from "@xyflow/react";
 import type {
-	EdgeBackend,
 	NestedNode,
 	NodeBackend,
-	Query,
 	SolutionModel,
 	TableData,
+	VersionFrontend,
 } from "@/features/modals/canva/types";
 
 /**
@@ -18,10 +17,9 @@ import type {
  */
 export function transformSolutionModel(solution: SolutionModel): {
 	name: string;
-	initialNodes: Node<TableData>[];
-	initialEdges: EdgeBackend[];
-	queries: Query[];
+	versions: VersionFrontend[];
 	solutionId: string;
+	last_version_saved: string;
 } {
 	/**
 	 * Maps a NodeBackend or NestedNode to a Node<TableData> object.
@@ -61,18 +59,21 @@ export function transformSolutionModel(solution: SolutionModel): {
 		}));
 	}
 
-	const initialNodes = solution.submodels.flatMap((submodel) =>
-		submodel.nodes.map((node) => mapNode(node)),
-	);
-
-	const initialEdges = solution.submodels.flatMap((submodel) => submodel.edges);
-	const queries = solution.queries;
+	const versions = solution.versions.map((version) => ({
+		queries: version.queries,
+		nodes: version.submodels.flatMap((submodel) =>
+			submodel.nodes.map((node) => mapNode(node))
+		),
+		edges: version.submodels.flatMap((submodel) => submodel.edges),
+		description: version.description,
+		solution_id: version.solution_id,
+		_id: version._id,
+	}));
 
 	return {
 		name: solution.name,
-		initialNodes,
-		initialEdges,
-		queries,
+		versions: versions,
 		solutionId: solution._id,
+		last_version_saved: solution.last_version_saved,
 	};
 }

--- a/src/state/canvaStore.ts
+++ b/src/state/canvaStore.ts
@@ -134,6 +134,7 @@ export const useCanvasStore = create<CanvasState>()(
 				nodes: state.nodes,
 				edges: state.edges,
 				queries: state.queries,
+				selectedVersionId: state.selectedVersionId,
 			}),
 			onRehydrateStorage: () => (state) => {
 				state?.setHasHydrated(true);

--- a/src/state/canvaStore.ts
+++ b/src/state/canvaStore.ts
@@ -1,7 +1,11 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
-import type { Query, TableData } from "@/features/modals/canva/types";
+import type {
+	Query,
+	TableData,
+	VersionFrontend,
+} from "@/features/modals/canva/types";
 import {
 	applyEdgeChanges,
 	applyNodeChanges,
@@ -12,6 +16,8 @@ import {
 } from "@xyflow/react";
 
 export type CanvasState = {
+	versions: VersionFrontend[];
+	selectedVersionId: string;
 	nodes: Node<TableData>[];
 	edges: Edge[];
 	queries: Query[];
@@ -20,6 +26,8 @@ export type CanvasState = {
 	setQueries: (queries: Query[]) => void;
 	setNodes: (nodes: Node<TableData>[]) => void;
 	setEdges: (edges: Edge[]) => void;
+	setVersions: (versions: VersionFrontend[]) => void;
+	setSelectedVersionId: (id: string) => void;
 	addNode: (node: Node<TableData>) => void;
 	addEdge: (edge: Edge) => void;
 	editNode: (nodeId: string, newNode: Node<TableData>) => void;
@@ -39,6 +47,13 @@ export const useCanvasStore = create<CanvasState>()(
 			edges: [],
 			queries: [],
 			id: "",
+			versions: [],
+			selectedVersionId: "",
+			setSelectedVersionId: (id) => {
+				set((state) => {
+					state.selectedVersionId = id;
+				});
+			},
 			setId: (id) => {
 				set((state) => {
 					state.id = id;
@@ -57,6 +72,11 @@ export const useCanvasStore = create<CanvasState>()(
 			setEdges: (edges) => {
 				set((state) => {
 					state.edges = edges;
+				});
+			},
+			setVersions: (versions) => {
+				set((state) => {
+					state.versions = versions;
 				});
 			},
 			addNode: (node) => {
@@ -90,7 +110,7 @@ export const useCanvasStore = create<CanvasState>()(
 			removeQuery: (queryString) => {
 				set((state) => {
 					state.queries = state.queries.filter(
-						(q) => q.full_query !== queryString,
+						(q) => q.full_query !== queryString
 					);
 				});
 			},
@@ -118,6 +138,23 @@ export const useCanvasStore = create<CanvasState>()(
 			onRehydrateStorage: () => (state) => {
 				state?.setHasHydrated(true);
 			},
-		},
-	),
+		}
+	)
 );
+
+export const canvaSelector = (state: CanvasState) => ({
+	id: state.id,
+	nodes: state.nodes,
+	edges: state.edges,
+	editNode: state.editNode,
+	addEdge: state.addEdge,
+	onNodesChange: state.onNodesChange,
+	onEdgesChange: state.onEdgesChange,
+	addNode: state.addNode,
+	versions: state.versions,
+	selectedVersionId: state.selectedVersionId,
+	setSelectedVersionId: state.setSelectedVersionId,
+	setNodes: state.setNodes,
+	setEdges: state.setEdges,
+	setQueries: state.setQueries,
+});


### PR DESCRIPTION
### Changes

- Added frontend support to manage and display multiple versions of solutions
- Updated the state store (canvaStore) to include the list of available versions and the current selected version.
- Modified the data loading logic in DiagramView to initialize nodes, edges, and queries on the selected version.
- Visual Selected in the header (LogoWithSelect) that allows switching between versions, updating the displayed diagram accordingly.
- Adapted the solution model conversion logic (solutionConversion) to support multiple versions, extracting nodes, edges, and queries from each version.


---

#30 
