### PR TITLE
feat: edit query

### DIFF
--- a/src/features/modals/canva/components/Queries/BtnNewQuery.tsx
+++ b/src/features/modals/canva/components/Queries/BtnNewQuery.tsx
@@ -1,8 +1,9 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { ModalNewQuery } from "./ModalNewQuery";
 
 export const BtnNewQuery = () => {
 	const modalRef = useRef<HTMLDialogElement>(null);
+	const [queryText, setQueryText] = useState("");
 	return (
 		<>
 			<button
@@ -17,7 +18,12 @@ export const BtnNewQuery = () => {
 				</div>
 			</button>
 
-			<ModalNewQuery modalRef={modalRef} mode="create"/>
+			<ModalNewQuery
+				modalRef={modalRef}
+				mode="create"
+				queryText={queryText}
+				setQueryText={setQueryText}
+			/>
 		</>
 	);
 };

--- a/src/features/modals/canva/components/Queries/BtnNewQuery.tsx
+++ b/src/features/modals/canva/components/Queries/BtnNewQuery.tsx
@@ -17,7 +17,7 @@ export const BtnNewQuery = () => {
 				</div>
 			</button>
 
-			<ModalNewQuery modalRef={modalRef} />
+			<ModalNewQuery modalRef={modalRef} mode="create"/>
 		</>
 	);
 };

--- a/src/features/modals/canva/components/Queries/DropDownQuerys.tsx
+++ b/src/features/modals/canva/components/Queries/DropDownQuerys.tsx
@@ -6,8 +6,12 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { MoreButton } from "../MoreButton";
+import { useRef } from "react";
+import { ModalNewQuery } from "./ModalNewQuery";
+import type { Query } from "../../types";
 
-export const DropDownQuerys = () => {
+export const DropDownQuerys = ({ editQuery }: { editQuery: Query }) => {
+	const modalRef = useRef<HTMLDialogElement>(null);
 	return (
 		<div className="absolute bottom-1 right-1">
 			<ManagedDropdownMenu>
@@ -28,7 +32,9 @@ export const DropDownQuerys = () => {
 					<DropdownMenuItem
 						className="hover:!bg-cuartenary-gray"
 						type="normal"
-						onClick={() => {}}
+						onClick={() => {
+							if (modalRef.current) modalRef.current.showModal();
+						}}
 					>
 						<svg
 							width="16"
@@ -67,6 +73,7 @@ export const DropDownQuerys = () => {
 					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</ManagedDropdownMenu>
+			<ModalNewQuery modalRef={modalRef} mode="edit" queryEdit={editQuery} />
 		</div>
 	);
 };

--- a/src/features/modals/canva/components/Queries/DropDownQuerys.tsx
+++ b/src/features/modals/canva/components/Queries/DropDownQuerys.tsx
@@ -14,7 +14,7 @@ export const DropDownQuerys = ({ editQuery }: { editQuery: Query }) => {
 	const modalRef = useRef<HTMLDialogElement>(null);
 	const [queryText, setQueryText] = useState("");
 	return (
-		<div className="absolute bottom-1.5 right-[-3px]">
+		<div className="absolute bottom-1.5 right-[0px]">
 			<ManagedDropdownMenu>
 				<DropdownMenuTrigger asChild>
 					<MoreButton

--- a/src/features/modals/canva/components/Queries/DropDownQuerys.tsx
+++ b/src/features/modals/canva/components/Queries/DropDownQuerys.tsx
@@ -14,7 +14,7 @@ export const DropDownQuerys = ({ editQuery }: { editQuery: Query }) => {
 	const modalRef = useRef<HTMLDialogElement>(null);
 	const [queryText, setQueryText] = useState("");
 	return (
-		<div className="absolute bottom-1 right-1">
+		<div className="absolute bottom-1.5 right-[-3px]">
 			<ManagedDropdownMenu>
 				<DropdownMenuTrigger asChild>
 					<MoreButton

--- a/src/features/modals/canva/components/Queries/DropDownQuerys.tsx
+++ b/src/features/modals/canva/components/Queries/DropDownQuerys.tsx
@@ -6,12 +6,13 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { MoreButton } from "../MoreButton";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { ModalNewQuery } from "./ModalNewQuery";
 import type { Query } from "../../types";
 
 export const DropDownQuerys = ({ editQuery }: { editQuery: Query }) => {
 	const modalRef = useRef<HTMLDialogElement>(null);
+	const [queryText, setQueryText] = useState("");
 	return (
 		<div className="absolute bottom-1 right-1">
 			<ManagedDropdownMenu>
@@ -20,7 +21,6 @@ export const DropDownQuerys = ({ editQuery }: { editQuery: Query }) => {
 						className="text-lighter-gray "
 						onClick={(e) => {
 							e.stopPropagation();
-							console.log("Trigger clicked");
 						}}
 					/>
 				</DropdownMenuTrigger>
@@ -34,6 +34,7 @@ export const DropDownQuerys = ({ editQuery }: { editQuery: Query }) => {
 						type="normal"
 						onClick={() => {
 							if (modalRef.current) modalRef.current.showModal();
+							setQueryText(editQuery?.full_query || "");
 						}}
 					>
 						<svg
@@ -73,7 +74,13 @@ export const DropDownQuerys = ({ editQuery }: { editQuery: Query }) => {
 					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</ManagedDropdownMenu>
-			<ModalNewQuery modalRef={modalRef} mode="edit" queryEdit={editQuery} />
+			<ModalNewQuery
+				modalRef={modalRef}
+				mode="edit"
+				queryEdit={editQuery}
+				queryText={queryText}
+				setQueryText={setQueryText}
+			/>
 		</div>
 	);
 };

--- a/src/features/modals/canva/components/Queries/ModalNewQuery.tsx
+++ b/src/features/modals/canva/components/Queries/ModalNewQuery.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
-import { useRef, useState, type RefObject } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 import { ModalSelectDocs } from "./ModalSelectDocs";
 import type { Query } from "../../types";
 
@@ -8,18 +8,22 @@ type ModalProps = {
 	modalRef: RefObject<HTMLDialogElement | null>;
 	queryEdit?: Query;
 	mode: "create" | "edit";
+	queryText: string;
+	setQueryText: (query: string) => void;
 };
 
 export const ModalNewQuery = ({
 	modalRef,
 	mode = "create",
 	queryEdit,
+	queryText,
+	setQueryText,
 }: ModalProps) => {
 	const nextModalRef = useRef<HTMLDialogElement>(null);
 
 	const handleClose = () => {
 		modalRef.current?.close();
-		setNewQuery("");
+		setQueryText("");
 	};
 
 	const handleSubmit = () => {
@@ -27,14 +31,22 @@ export const ModalNewQuery = ({
 		nextModalRef.current?.showModal();
 	};
 
-	const [newQuery, setNewQuery] = useState("");
-	if (mode === "edit") {
-		setNewQuery(queryEdit?.full_query || "");
-	}
+	useEffect(() => {
+		if (mode === "edit") {
+			setQueryText(queryEdit?.full_query || "");
+		} else {
+			setQueryText("");
+		}
+	}, [queryEdit, mode, setQueryText]);
 
 	return (
 		<>
-			<Modal title="Nueva Consulta" modalRef={modalRef} onClose={() => {}}>
+			<Modal
+				title="Nueva Consulta"
+				modalRef={modalRef}
+				onClose={() => {}}
+				key={queryEdit?.id || "create-modal"}
+			>
 				<>
 					<div className="my-13 gap-5 flex justify-between items-start flex-col">
 						<label
@@ -46,8 +58,8 @@ export const ModalNewQuery = ({
 						<textarea
 							placeholder="Escribe tu consulta"
 							id="docName"
-							value={newQuery}
-							onChange={(e) => setNewQuery(e.target.value)}
+							value={queryText}
+							onChange={(e) => setQueryText(e.target.value)}
 							className="text-h4 w-160 h-36 py-3 px-5 border border-gray rounded-md bg-terciary-gray focus:outline-none"
 						/>
 					</div>
@@ -75,10 +87,10 @@ export const ModalNewQuery = ({
 			<ModalSelectDocs
 				nextModalRef={nextModalRef}
 				modalRef={modalRef}
-				queryText={newQuery}
+				queryText={queryText}
 				queryEdit={queryEdit}
 				mode={mode}
-				setNewQuery={setNewQuery}
+				setQueryText={setQueryText}
 			/>
 		</>
 	);

--- a/src/features/modals/canva/components/Queries/ModalNewQuery.tsx
+++ b/src/features/modals/canva/components/Queries/ModalNewQuery.tsx
@@ -2,12 +2,19 @@ import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
 import { useRef, useState, type RefObject } from "react";
 import { ModalSelectDocs } from "./ModalSelectDocs";
+import type { Query } from "../../types";
 
 type ModalProps = {
 	modalRef: RefObject<HTMLDialogElement | null>;
+	queryEdit?: Query;
+	mode: "create" | "edit";
 };
 
-export const ModalNewQuery = ({ modalRef }: ModalProps) => {
+export const ModalNewQuery = ({
+	modalRef,
+	mode = "create",
+	queryEdit,
+}: ModalProps) => {
 	const nextModalRef = useRef<HTMLDialogElement>(null);
 
 	const handleClose = () => {
@@ -21,6 +28,9 @@ export const ModalNewQuery = ({ modalRef }: ModalProps) => {
 	};
 
 	const [newQuery, setNewQuery] = useState("");
+	if (mode === "edit") {
+		setNewQuery(queryEdit?.full_query || "");
+	}
 
 	return (
 		<>
@@ -65,7 +75,9 @@ export const ModalNewQuery = ({ modalRef }: ModalProps) => {
 			<ModalSelectDocs
 				nextModalRef={nextModalRef}
 				modalRef={modalRef}
-				newQuery={newQuery}
+				queryText={newQuery}
+				queryEdit={queryEdit}
+				mode={mode}
 				setNewQuery={setNewQuery}
 			/>
 		</>

--- a/src/features/modals/canva/components/Queries/ModalSelectDocs.tsx
+++ b/src/features/modals/canva/components/Queries/ModalSelectDocs.tsx
@@ -1,27 +1,35 @@
+import { useState, type RefObject } from "react";
 import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
-import { useCanvasStore } from "@/state/canvaStore";
-import { useState, type RefObject } from "react";
 import { ArrowLeft } from "lucide-react";
+import { useCanvasStore } from "@/state/canvaStore";
+import { useUniqueId } from "@/hooks/use-unique-id";
+import clsx from "clsx"; // Asegúrate de tener esta dependencia instalada
+import type { Query } from "../../types";
 
 type ModalProps = {
 	nextModalRef: RefObject<HTMLDialogElement | null>;
 	modalRef: RefObject<HTMLDialogElement | null>;
-	newQuery: string;
+	queryText: string;
+	queryEdit?: Query;
+	mode: "create" | "edit";
 	setNewQuery: (query: string) => void;
 };
 
 export const ModalSelectDocs = ({
 	nextModalRef,
-	newQuery,
 	modalRef,
+	queryText,
+	queryEdit,
+	mode,
 	setNewQuery,
 }: ModalProps) => {
-	const words = newQuery.trim().split(/\s+/);
+	const words = queryText.trim().split(/\s+/);
 	const [selectedWords, setSelectedWords] = useState<string[]>([]);
 	const [error, setError] = useState(false);
 
-	const { addQuery } = useCanvasStore();
+	const { addQuery, editQuery } = useCanvasStore();
+	const generateId = useUniqueId();
 
 	const toggleWord = (word: string) => {
 		setSelectedWords((prev) =>
@@ -31,32 +39,35 @@ export const ModalSelectDocs = ({
 	};
 
 	const handleClose = () => {
-		if (nextModalRef.current) {
-			nextModalRef.current.close();
-		}
+		nextModalRef.current?.close?.();
 		setNewQuery("");
 		setSelectedWords([]);
+		setError(false);
 	};
 
 	const handleReturnModal = () => {
 		setSelectedWords([]);
-		nextModalRef.current?.close();
-		modalRef.current?.showModal();
+		setError(false);
+		nextModalRef.current?.close?.();
+		modalRef.current?.showModal?.();
 	};
 
-	const handleSubmit = () => {
-		if (selectedWords.length === 0) {
+	const handleSubmitQuery = () => {
+		if (!queryText.trim() || selectedWords.length === 0) {
 			setError(true);
 			return;
 		}
 
-		addQuery({
-			full_query: newQuery,
+		const queryData = {
+			id: mode === "create" ? generateId() : queryEdit?.id || "",
+			full_query: queryText,
 			collections: selectedWords,
-		});
-		setNewQuery("");
-		setSelectedWords([]);
-		setError(false);
+		};
+
+		mode === "create"
+			? addQuery(queryData)
+			: editQuery(queryData.id, queryData);
+
 		handleClose();
 	};
 
@@ -67,18 +78,21 @@ export const ModalSelectDocs = ({
 					<p className="text-h3 text-secondary-white mb-2">
 						Escoge tus colecciones
 					</p>
+
 					<div className="flex flex-wrap gap-3">
 						{words.map((word) => (
 							<button
 								key={`word-${word}`}
 								type="button"
 								onClick={() => toggleWord(word)}
-								className={`cursor-pointer px-4 py-2 rounded-lg border border-gray transition-colors duration-200
-								${
+								className={clsx(
+									"cursor-pointer px-4 py-2 rounded-lg border border-gray transition-colors duration-200",
 									selectedWords.includes(word)
 										? "bg-gray text-white"
-										: "bg-transparent text-secondary-white"
-								}`}
+										: "bg-transparent text-secondary-white",
+								)}
+								aria-pressed={selectedWords.includes(word)}
+								aria-label={`Seleccionar colección ${word}`}
 							>
 								{word}
 							</button>
@@ -87,12 +101,14 @@ export const ModalSelectDocs = ({
 
 					{error && (
 						<p className="text-red-500 mt-4 text-sm">
-							Debes seleccionar al menos una palabra.
+							Debes seleccionar al menos una palabra y escribir una consulta.
 						</p>
 					)}
+
 					<Button
 						onClick={handleReturnModal}
 						className="cursor-pointer absolute top-[-97px] left-0 group transition-all duration-600"
+						aria-label="Volver"
 					>
 						<ArrowLeft className="text-secondary-white group-hover:text-white !w-auto !h-[26px]" />
 					</Button>
@@ -100,20 +116,22 @@ export const ModalSelectDocs = ({
 
 				<div className="flex justify-end gap-5">
 					<Button
-						variant={"outline"}
+						variant="outline"
 						type="button"
 						onClick={handleClose}
 						className="cursor-pointer text-h3 text-white bg-red border-none hover:bg-red-dark hover:text-white"
+						aria-label="Cancelar"
 					>
 						Cancelar
 					</Button>
 					<Button
-						variant={"outline"}
+						variant="outline"
 						type="button"
-						onClick={handleSubmit}
+						onClick={handleSubmitQuery}
 						className="cursor-pointer text-h3 text-white bg-green border-none hover:bg-green-dark hover:text-white"
+						aria-label={mode === "edit" ? "Guardar cambios" : "Crear consulta"}
 					>
-						Crear consulta
+						{mode === "edit" ? "Guardar cambios" : "Crear consulta"}
 					</Button>
 				</div>
 			</>

--- a/src/features/modals/canva/components/Queries/ModalSelectDocs.tsx
+++ b/src/features/modals/canva/components/Queries/ModalSelectDocs.tsx
@@ -13,7 +13,7 @@ type ModalProps = {
 	queryText: string;
 	queryEdit?: Query;
 	mode: "create" | "edit";
-	setNewQuery: (query: string) => void;
+	setQueryText: (query: string) => void;
 };
 
 export const ModalSelectDocs = ({
@@ -22,7 +22,7 @@ export const ModalSelectDocs = ({
 	queryText,
 	queryEdit,
 	mode,
-	setNewQuery,
+	setQueryText,
 }: ModalProps) => {
 	const words = queryText.trim().split(/\s+/);
 	const [selectedWords, setSelectedWords] = useState<string[]>([]);
@@ -40,7 +40,7 @@ export const ModalSelectDocs = ({
 
 	const handleClose = () => {
 		nextModalRef.current?.close?.();
-		setNewQuery("");
+		setQueryText("");
 		setSelectedWords([]);
 		setError(false);
 	};
@@ -80,9 +80,9 @@ export const ModalSelectDocs = ({
 					</p>
 
 					<div className="flex flex-wrap gap-3">
-						{words.map((word) => (
+						{words.map((word, index) => (
 							<button
-								key={`word-${word}`}
+								key={`${index}-${word}`}
 								type="button"
 								onClick={() => toggleWord(word)}
 								className={clsx(

--- a/src/features/modals/canva/components/Queries/QueryItem.tsx
+++ b/src/features/modals/canva/components/Queries/QueryItem.tsx
@@ -21,7 +21,7 @@ export const QueryItem = ({ query }: { query: Query }) => {
 			<span className="text-p text-secondary-white">
 				Colecciones involucradas
 			</span>
-			<div className="flex flex-wrap gap-2.5 w-full">
+			<div className="flex flex-wrap gap-2.5 w-full pr-3">
 				{query.collections.map((collection) => (
 					<div
 						key={`${collection}-query`}

--- a/src/features/modals/canva/components/Queries/QueryItem.tsx
+++ b/src/features/modals/canva/components/Queries/QueryItem.tsx
@@ -32,7 +32,7 @@ export const QueryItem = ({ query }: { query: Query }) => {
 				))}
 			</div>
 
-			<DropDownQuerys />
+			<DropDownQuerys editQuery={query} />
 		</div>
 	);
 };

--- a/src/features/modals/canva/types.ts
+++ b/src/features/modals/canva/types.ts
@@ -25,6 +25,7 @@ export interface TableNodeProps {
 }
 
 export interface Query {
+	id: string;
 	full_query: string;
 	collections: string[];
 }

--- a/src/state/canvaStore.ts
+++ b/src/state/canvaStore.ts
@@ -157,6 +157,7 @@ export const useCanvasStore = create<CanvasState>()(
 				edges: state.edges,
 				queries: state.queries,
 				selectedVersionId: state.selectedVersionId,
+				versions: state.versions,
 			}),
 			onRehydrateStorage: () => (state) => {
 				state?.setHasHydrated(true);

--- a/src/state/canvaStore.ts
+++ b/src/state/canvaStore.ts
@@ -32,6 +32,7 @@ export type CanvasState = {
 	addEdge: (edge: Edge) => void;
 	addQuery: (queries: Query) => void;
 	editNode: (nodeId: string, newNode: Node<TableData>) => void;
+	editQuery: (queryId: string, newQuery: Query) => void;
 	removeNode: (nodeId: string) => void;
 	removeEdge: (edgeId: string) => void;
 	removeQuery: (queryString: string) => void;
@@ -103,6 +104,16 @@ export const useCanvasStore = create<CanvasState>()(
 					}
 				});
 			},
+			editQuery: (queryId, newQuery) => {
+				set((state) => {
+					const index = state.queries.findIndex(
+						(query) => query.id === queryId,
+					);
+					if (index !== -1) {
+						state.queries[index] = newQuery;
+					}
+				});
+			},
 			removeNode: (nodeId) => {
 				set((state) => {
 					state.nodes = state.nodes.filter((n) => n.id !== nodeId);
@@ -116,7 +127,7 @@ export const useCanvasStore = create<CanvasState>()(
 			removeQuery: (queryString) => {
 				set((state) => {
 					state.queries = state.queries.filter(
-						(q) => q.full_query !== queryString
+						(q) => q.full_query !== queryString,
 					);
 				});
 			},
@@ -145,8 +156,8 @@ export const useCanvasStore = create<CanvasState>()(
 			onRehydrateStorage: () => (state) => {
 				state?.setHasHydrated(true);
 			},
-		}
-	)
+		},
+	),
 );
 
 export const canvaSelector = (state: CanvasState) => ({

--- a/src/state/canvaStore.ts
+++ b/src/state/canvaStore.ts
@@ -28,6 +28,7 @@ export type CanvasState = {
 	setEdges: (edges: Edge[]) => void;
 	setVersions: (versions: VersionFrontend[]) => void;
 	setSelectedVersionId: (id: string) => void;
+	getQueryById: (queryId: string) => Query | undefined;
 	addNode: (node: Node<TableData>) => void;
 	addEdge: (edge: Edge) => void;
 	addQuery: (queries: Query) => void;
@@ -80,6 +81,10 @@ export const useCanvasStore = create<CanvasState>()(
 				set((state) => {
 					state.versions = versions;
 				});
+			},
+			getQueryById: (queryId) => {
+				const query = get().queries.find((q) => q.id === queryId);
+				return query;
 			},
 			addNode: (node) => {
 				set((state) => {


### PR DESCRIPTION
### Changes

- Added support for **editing queries** by introducing a new `"edit"` mode in the modal component.
- Renamed state and props (e.g., `setNewQuery` to `setQueryText`) for clarity and consistency across components.
- Ensured the modal resets its state properly when switching between edit and create modes, including handling cancel actions.
- Passed `queryTextState` and `setQueryText` between components to synchronize query input state during edit operations.

---

#33 